### PR TITLE
resolve null when there is no output json

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,7 +296,7 @@ export class PowerJS {
             return handleError(errjson);
           }
 
-          resolve(new Result(json));
+          resolve(json ? new Result(json) : null);
         },
       });
     });


### PR DESCRIPTION
Some PowerShell commands don't return anything on success, such as `Remove-SMBMapping -LocalPath Z: -Force`.
This is avoids an error trying create a Result object from nothing.