### PR TITLE
Promises should reject rather than throw errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import {
   IncompleteCommand,
   StartTimeoutException,
   TimeoutException,
-  handleError,
+  getError,
 } from "./lib/errors.js";
 
 const beforerun = `
@@ -293,7 +293,8 @@ export class PowerJS {
           const { json, errjson } = extractData(out);
 
           if (errjson != null) {
-            return handleError(errjson);
+            reject(getError(errjson));
+            return;
           }
 
           resolve(json ? new Result(json) : null);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -42,7 +42,7 @@ export function getErrorRecord(err) {
   return errClass;
 }
 
-export function handleError(errObj, name = "<execution>") {
+export function getError(errObj, name = "<execution>") {
   const err = new (getErrorRecord(errObj.code))(
     errObj.line,
     errObj.pos,
@@ -58,5 +58,5 @@ export function handleError(errObj, name = "<execution>") {
   stack.splice(1, 0, `    at ${name}:${errObj.line}:${errObj.pos}`);
   err.stack = stack.join("\n");
 
-  throw err;
+  return err;
 }


### PR DESCRIPTION
Then in the caller we can try ... catch the error and handle it gracefully.