### PR TITLE
Export ErrorRecord

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import { Extension, ExtensionClass } from "./ext/index.js";
+import { ErrorRecord } from "./lib/errors.js";
 import { Result } from "./lib/result.js";
 
 /**
@@ -125,4 +126,4 @@ declare class PowerJS {
   };
 }
 
-export { PowerJS, Extension, Result, PowerJSOptions, RunAsOptions, PowerJSExecConfig };
+export { PowerJS, ErrorRecord, Extension, Result, PowerJSOptions, RunAsOptions, PowerJSExecConfig };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import { assert, extractData } from "./lib/utils.js";
 import { Extension } from "./ext/index.js";
 import { Result } from "./lib/result.js";
 import {
+  ErrorRecord,
   IncompleteCommand,
   StartTimeoutException,
   TimeoutException,
@@ -304,4 +305,4 @@ export class PowerJS {
   }
 }
 
-export { Extension, Result };
+export { Extension, Result, ErrorRecord };

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -1,0 +1,19 @@
+/**
+ * A class that holds the error after an execution
+ */
+export class ErrorRecord extends Error {
+  /**
+   * The line number where the error occured.
+   */
+  line: number;
+  /**
+   * The position in the line where the error occured.
+   */
+  pos: number;
+  /**
+   * The error code returned.
+   */
+  code: string;
+
+  constructor(line: number, pos: number, code: string);
+}


### PR DESCRIPTION
This allows the use of instanceof against caught errors so we can get the code.