### PR TITLE
Allow arguments and options to be passed to child process spawn

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,11 +166,11 @@ export class PowerJS {
     }, 8000);
   }
 
-  #findOptimalShell(additionalShellNames) {
+  #findOptimalShell(additionalShellNames, shell_args) {
     // Find optimal shell
     for (const sname of additionalShellNames) {
       try {
-        this.#child = spawn(sname);
+        this.#child = spawn(sname, shell_args);
         this.#shell = sname;
         break;
       } catch (e) {
@@ -245,6 +245,7 @@ export class PowerJS {
     autoStart = true,
     extensions = [],
     dlls = {},
+    shell_args = [],
   } = {}) {
     additionalShellNames.push("pwsh", "powershell");
 
@@ -255,7 +256,7 @@ export class PowerJS {
       }
     }
 
-    this.#findOptimalShell(additionalShellNames);
+    this.#findOptimalShell(additionalShellNames, shell_args);
     if (this.#child == null) {
       throw new Error(
         "Cannot find a powershell interpreter! Try installing powershell or adding your one!"

--- a/index.js
+++ b/index.js
@@ -166,11 +166,11 @@ export class PowerJS {
     }, 8000);
   }
 
-  #findOptimalShell(additionalShellNames, shell_args) {
+  #findOptimalShell(additionalShellNames, shellArgs) {
     // Find optimal shell
     for (const sname of additionalShellNames) {
       try {
-        this.#child = spawn(sname, shell_args);
+        this.#child = spawn(sname, shellArgs);
         this.#shell = sname;
         break;
       } catch (e) {
@@ -245,7 +245,7 @@ export class PowerJS {
     autoStart = true,
     extensions = [],
     dlls = {},
-    shell_args = [],
+    shellArgs = [],
   } = {}) {
     additionalShellNames.push("pwsh", "powershell");
 
@@ -256,7 +256,7 @@ export class PowerJS {
       }
     }
 
-    this.#findOptimalShell(additionalShellNames, shell_args);
+    this.#findOptimalShell(additionalShellNames, shellArgs);
     if (this.#child == null) {
       throw new Error(
         "Cannot find a powershell interpreter! Try installing powershell or adding your one!"

--- a/index.js
+++ b/index.js
@@ -166,11 +166,11 @@ export class PowerJS {
     }, 8000);
   }
 
-  #findOptimalShell(additionalShellNames, shellArgs) {
+  #findOptimalShell(additionalShellNames, shellArgs, options) {
     // Find optimal shell
     for (const sname of additionalShellNames) {
       try {
-        this.#child = spawn(sname, shellArgs);
+        this.#child = spawn(sname, shellArgs, options);
         this.#shell = sname;
         break;
       } catch (e) {
@@ -246,6 +246,7 @@ export class PowerJS {
     extensions = [],
     dlls = {},
     shellArgs = [],
+    options = {},
   } = {}) {
     additionalShellNames.push("pwsh", "powershell");
 
@@ -256,7 +257,7 @@ export class PowerJS {
       }
     }
 
-    this.#findOptimalShell(additionalShellNames, shellArgs);
+    this.#findOptimalShell(additionalShellNames, shellArgs, options);
     if (this.#child == null) {
       throw new Error(
         "Cannot find a powershell interpreter! Try installing powershell or adding your one!"


### PR DESCRIPTION
The current implementation does not allow specifying any arguments or options to pass to `child_process.spawn` when creating a new instance of `PowerJS`. This pull request modifies the constructor of `PowerJS` to accept optional `shellArgs` and `options` in the object of options passed to the constructor. These are then passed to the `args` and `options` arguments of `child_process.spawn`, respectively. If `shellArgs` and/or `options` is not passed to the constructor of `PowerJS`, then it is ignored, as per the current implementation.

Uses include passing flags to the initial invocation of PowerShell ([available flags](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1)) and passing options that affect the child process itself, such as the current working directory or environment variables for the child process.

Closes #8 since `-NoProfile` can be one of the arguments passed with `shellArgs`.