### PR TITLE
Allow PowerJS to start when PowerShell profiles take a long time to load

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ export class PowerJS {
     } else {
       this.#working = false; // Powershell Session is initiated!
       clearTimeout(this.#timeouts.start);
-      assert(this.#readerr.replaceAll(/Loading personal and system profiles took \d+ms./g, '').length, 0, "Powershell init has an error!");
+      assert(this.#readerr.replaceAll(/Loading personal and system profiles took \d+ms\./g, '').trim().length, 0, "Powershell init has an error!");
     } // No process() because we need to bypass introduction data (like Powershell version...)
 
     this.#readout = "";

--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ export class PowerJS {
     } else {
       this.#working = false; // Powershell Session is initiated!
       clearTimeout(this.#timeouts.start);
-      assert(this.#readerr.length, 0, "Powershell init has an error!");
+      assert(this.#readerr.replaceAll(/Loading personal and system profiles took \d+ms./g, '').length, 0, "Powershell init has an error!");
     } // No process() because we need to bypass introduction data (like Powershell version...)
 
     this.#readout = "";


### PR DESCRIPTION
As described in #12, PowerShell will write a message to `stderr` if loading the PowerShell profiles takes longer than 500 ms, causing an error to be thrown when `PowerJS` is instantiated. This pull request allows the instantiation of `PowerJS` even when the profiles take more than 500 ms to load by altering the statement checking `#readerr` to instead check a copy of `#readerr` that has had all matches to the RegEx `/Loading personal and system profiles took \d+ms\./g` replaced with the empty string and extraneous whitespace trimmed away.

Closes #12.